### PR TITLE
Immutable support for MooseX::UndefTolerant

### DIFF
--- a/lib/MooseX/UndefTolerant.pm
+++ b/lib/MooseX/UndefTolerant.pm
@@ -4,11 +4,15 @@ use Moose qw();
 use Moose::Exporter;
 
 use MooseX::UndefTolerant::Attribute;
+use MooseX::UndefTolerant::Constructor;
 
 our $VERSION = '0.04';
 
 Moose::Exporter->setup_import_methods(
-    class_metaroles => { attribute => [ 'MooseX::UndefTolerant::Attribute' ] }
+    class_metaroles => { 
+           attribute => [ 'MooseX::UndefTolerant::Attribute' ],
+           constructor => [ 'MooseX::UndefTolerant::Constructor' ],
+    }
 );
 
 1;

--- a/lib/MooseX/UndefTolerant.pm
+++ b/lib/MooseX/UndefTolerant.pm
@@ -21,7 +21,7 @@ __END__
 
 =head1 NAME
 
-MooseX::UndefTolerant - Make your attribute(s) tolerant to undef intitialization
+MooseX::UndefTolerant - Make your attribute(s) tolerant to undef initialization
 
 =head1 SYNOPSIS
 
@@ -94,6 +94,20 @@ real solution was:
 Or some type of codemulch using ternarys.  This module allows you to make
 your attributes more tolerant of undef so that you can keep the first
 example: have your cake and eat it too!
+
+=head1 USE IN YOUR MOOSE EXPORTER
+
+If you already have a custom Moose exporter class and you want this
+behaviour everywhere, you can add these roles there with this call, in
+your C<init_meta> routine:
+
+  Moose::Util::MetaRole::apply_metaroles(
+    class_metaroles => { 
+      attribute => [ 'MooseX::UndefTolerant::Attribute' ],
+      constructor => [ 'MooseX::UndefTolerant::Constructor' ],
+    },
+    for => $args{for_class},
+  );
 
 =head1 PER ATTRIBUTE
 

--- a/lib/MooseX/UndefTolerant/Attribute.pm
+++ b/lib/MooseX/UndefTolerant/Attribute.pm
@@ -9,7 +9,7 @@ around('initialize_instance_slot', sub {
 
     # $_[2] is the hashref of options passed to the constructor. If our
     # parameter passed in was undef, pop it off the args...
-    pop unless (exists($_[2]->{$ia}) && defined($_[2]->{$ia}));
+    pop unless (defined $ia && exists($_[2]->{$ia}) && defined($_[2]->{$ia}));
 
     # Invoke the real init, as the above line cleared the unef
     $self->$orig(@_)

--- a/lib/MooseX/UndefTolerant/Constructor.pm
+++ b/lib/MooseX/UndefTolerant/Constructor.pm
@@ -6,11 +6,19 @@ around('_generate_slot_initializer', sub {
         my $self = shift;
         my $attr = $self->_attributes->[$_[0]]->init_arg;
 
-        my $tolerant_code = 
-             qq# delete \$params->{'$attr'} unless # . 
-             qq# exists \$params->{'$attr'} && defined \$params->{'$attr'};\n#;
+        # insert a line of code at the start of the initializer,
+        # clearing the param if it's undefined.
 
-        return $tolerant_code . $self->$orig(@_);
+        if (defined $attr) {
+                my $tolerant_code = 
+                     qq# delete \$params->{'$attr'} unless # . 
+                     qq# exists \$params->{'$attr'} && defined \$params->{'$attr'};\n#;
+
+                return $tolerant_code . $self->$orig(@_);
+        }
+        else {
+                return $self->$orig(@_);
+        }
 });
 
 no Moose::Role;

--- a/lib/MooseX/UndefTolerant/Constructor.pm
+++ b/lib/MooseX/UndefTolerant/Constructor.pm
@@ -1,0 +1,18 @@
+package MooseX::UndefTolerant::Constructor;
+use Moose::Role;
+
+around('_generate_slot_initializer', sub {
+        my $orig = shift;
+        my $self = shift;
+        my $attr = $self->_attributes->[$_[0]]->init_arg;
+
+        my $tolerant_code = 
+             qq# delete \$params->{'$attr'} unless # . 
+             qq# exists \$params->{'$attr'} && defined \$params->{'$attr'};\n#;
+
+        return $tolerant_code . $self->$orig(@_);
+});
+
+no Moose::Role;
+
+1;

--- a/t/immutable.t
+++ b/t/immutable.t
@@ -1,0 +1,33 @@
+use Test::More;
+
+package Foo;
+use Moose;
+use MooseX::UndefTolerant;
+
+has 'bar' => (
+    is => 'ro',
+    isa => 'Num',
+    predicate => 'has_bar'
+);
+
+__PACKAGE__->meta->make_immutable;
+
+package main;
+
+{
+    my $foo = Foo->new;
+    ok(!$foo->has_bar);
+}
+
+{
+    my $foo = Foo->new(bar => undef);
+    ok(!$foo->has_bar);
+}
+
+{
+    my $foo = Foo->new(bar => 1234);
+    cmp_ok($foo->bar, 'eq', 1234);
+    ok($foo->has_bar);
+}
+
+done_testing;


### PR DESCRIPTION
Hi,

This module was exactly what I needed, except that all my classes are immutable. I've added support for that in this branch, and it seems to work out OK. It's modifying the the generated constructor to check and delete undef parameters, just like the existing attribute role does.

I'd appreciate it if you'd take a look at these changes.

Thanks! 

Chris.
